### PR TITLE
Reduce chance that the HUD will shrink the viewport on cinematic-width displays.

### DIFF
--- a/Plugins/Enhanced HUD/XBLA.lua
+++ b/Plugins/Enhanced HUD/XBLA.lua
@@ -191,7 +191,7 @@ function Triggers.resize()
   Screen.map_rect.y = 0
   
   local min_aspect_ratio = 1.6
-  local max_aspect_ratio = 2.0
+  local max_aspect_ratio = 2.4
   local h = math.min(Screen.height, Screen.width / min_aspect_ratio)
   local w = math.min(Screen.width, h*max_aspect_ratio)
   Screen.world_rect.width = w


### PR DESCRIPTION
It's unclear to me why the HUD plugin limits the main view aspect ratio to 2:1, but there are many popular displays wider than that.